### PR TITLE
Add "About" page and content

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,6 +10,9 @@
     <div class="navbar-collapse collapse" id="navbar">
         <ul class="navbar-nav">
             <li class="nav-item mr-2">
+                <a class="nav-link {% if page.url == '/about/' %}active{% endif %}" href="/about/">about</a>
+            </li>
+            <li class="nav-item mr-2">
                 <a class="nav-link {% if page.url == '/archive/' %}active{% endif %}" href="/archive/">archive</a>
             </li>
             <li class="nav-item mr-2">

--- a/about.md
+++ b/about.md
@@ -7,7 +7,7 @@ title: About the Tech Workers Coalition Newsletter
 
 This newsletter is a project within the [Tech Workers Coalition](https://www.techworkerscoalition.org/). TWC is a worker-led, all-volunteer network building power through rank-and-file organizing and peer education.
 
-The current editorial collective was formed in April 2020 by [Danny S](https://twitter.com/daspitzberg), [Wendy L](https://twitter.com/dellsystem), [Jesse S](https://twitter.com/jesse_squires), [Felipe V](https://twitter.com/fvntr) and [Ana U](https://anaulin.org/), all current or former tech workers based in the San Francisco Bay Area.  We see ourselves as stewards, not owners, of this project, and hope for it to grow within the broader network. We do not (and can't possibly) speak for all of TWC.
+The current editorial collective was formed in April 2020 by [Danny S](https://twitter.com/daspitzberg), [Wendy L](https://twitter.com/dellsystem), [Jesse S](https://twitter.com/jesse_squires), [Felipe V](https://twitter.com/fvntr) and [Ana U](https://anaulin.org/), all current or former tech workers based in the San Francisco Bay Area. We see ourselves as stewards, not owners, of this project, and hope for it to grow within the broader network. We do not (and can't possibly) speak for all of TWC.
 
 Throughout 2018, a previous group of volunteers published issues which are available on this website under [Volume 1](https://news.techworkerscoalition.org/archive/#volume-1). That group is unfortunately no longer active, but we are grateful for their efforts as we form a new group and restart the newsletter.
 

--- a/about.md
+++ b/about.md
@@ -7,15 +7,17 @@ title: About the Tech Workers Coalition Newsletter
 
 This newsletter is a project within the [Tech Workers Coalition](https://www.techworkerscoalition.org/). TWC is a worker-led, all-volunteer network building power through rank-and-file organizing and peer education.
 
-The current editorial collective was formed in April 2020 by [Danny S](https://twitter.com/daspitzberg), [Wendy L](https://twitter.com/dellsystem), [Jesse S](https://twitter.com/jesse_squires), [Felipe V](https://twitter.com/fvntr) and [Ana U](https://anaulin.org/), all current or former tech workers based in the San Francisco Bay Area. We see ourselves as stewards, not owners, of this project, and hope for it to grow within the broader network. We do not (and can't possibly) speak for all of TWC.
+The current editorial collective was formed in April 2020 by [Danny S](https://twitter.com/daspitzberg), [Wendy L](https://twitter.com/dellsystem), [Jesse S](https://twitter.com/jesse_squires), [Felipe V](https://twitter.com/fvntr) and [Ana U](https://anaulin.org/), all current or former tech workers based in the San Francisco Bay Area.
 
-Throughout 2018, a previous group of volunteers published issues which are available on this website under [Volume 1](https://news.techworkerscoalition.org/archive/#volume-1). That group is unfortunately no longer active, but we are grateful for their efforts as we form a new group and restart the newsletter.
+We see ourselves as stewards, not owners, of this project, and hope for it to grow within the broader network. We do not (and can't possibly) speak for all of TWC.
+
+In 2018 and 2019, an early group of volunteers published a newsletter which is available on this website under [Volume 1](https://news.techworkerscoalition.org/archive/#volume-1). We’re grateful for their foundational work as we form a new group and restart the newsletter.
 
 ### Our vision and values
 
-Our goal with this newsletter is to help situate the tech industry within the broader social, political and economic context. We believe that, as tech workers, we have a role to play in making our industry better. We hope this newsletter will help build understanding and solidarity across roles and companies.
+Our aim with this newsletter is to help situate the tech industry within the broader social, political and economic context. We believe that, as tech workers, we have a role to play in making our industry better. We hope this newsletter will help build understanding and solidarity across roles and companies.
 
-We will share news, analysis and inspiration related to worker actions and working conditions in the tech industry. We will also occasionally examine the impact of the tech industry on society.
+We will share news, analysis, and inspiration related to worker actions and working conditions in the tech industry, and its impact on society.
 
 We will operate openly, welcome new contributors, and gratefully incorporate feedback. This project and its practices will evolve as we grow together with TWC.
 
@@ -31,6 +33,6 @@ We also welcome you to [subscribe](/subscribe/) to our newsletter!
 
 ### How we make decisions and grow
 
-As a small collective, we make decisions by loose consensus. We manage disagreement by embracing our differences while trying to serve our vision and values. 
+As a small collective, we make decisions by loose consensus: as we work towards our vision and values, we take a bias towards action, embrace our differences, and continually improve our editorial process and overall capacity.
 
-We encourage collaborators to be proactive in contributing content and providing feedback, and we plan to continually improve our editorial process and overall capacity. As more collaborators join our collective, we will evolve with input from everyone. 
+We encourage collaborators to be proactive in contributing content and providing feedback. As more collaborators join our collective, we will evolve this project. 

--- a/about.md
+++ b/about.md
@@ -1,0 +1,36 @@
+---
+layout: standalone
+title: About the Tech Workers Coalition Newsletter
+---
+
+### Who we are
+
+This newsletter is a project within the [Tech Workers Coalition](https://www.techworkerscoalition.org/). TWC is a worker-led, all-volunteer network building power through rank-and-file organizing and peer education.
+
+The current editorial collective was formed in April 2020 by [Danny S](https://twitter.com/daspitzberg), [Wendy L](https://twitter.com/dellsystem), [Jesse S](https://twitter.com/jesse_squires), [Felipe V](https://twitter.com/fvntr) and [Ana U](https://anaulin.org/), all current or former tech workers based in the San Francisco Bay Area.  We see ourselves as stewards, not owners, of this project, and hope for it to grow within the broader network. We do not (and can't possibly) speak for all of TWC.
+
+Throughout 2018, a previous group of volunteers published issues which are available on this website under [Volume 1](https://news.techworkerscoalition.org/archive/#volume-1). That group is unfortunately no longer active, but we are grateful for their efforts as we form a new group and restart the newsletter.
+
+### Our vision and values
+
+Our goal with this newsletter is to help situate the tech industry within the broader social, political and economic context. We believe that, as tech workers, we have a role to play in making our industry better. We hope this newsletter will help build understanding and solidarity across roles and companies.
+
+We will share news, analysis and inspiration related to worker actions and working conditions in the tech industry. We will also occasionally examine the impact of the tech industry on society.
+
+We will operate openly, welcome new contributors, and gratefully incorporate feedback. This project and its practices will evolve as we grow together with TWC.
+
+We intend to run this project as a model of the organizing we believe in: grassroots worker organizing with autonomy, accountability, and joy! We work in solidarity with existing movements towards workers' rights, equity, and justice.
+
+### How we engage contributors and collaborators
+
+We welcome contributions for general themes (workplace surveillance and that eerie feeling of being watched), specific stories (a report of vacuum cleaning robots programmed to trip interns), or anything else that aligns with our vision and values.
+
+If you have suggestions, contributions, or proposals to collaborate, you can contact our collective by email: <twcnewsletter@protonmail.com>. You can also open a [GitHub issue](https://github.com/techworkersco/techworkersco.github.io/issues).
+
+We also welcome you to [subscribe](/subscribe/) to our newsletter! 
+
+### How we make decisions and grow
+
+As a small collective, we make decisions by loose consensus. We manage disagreement by embracing our differences while trying to serve our vision and values. 
+
+We encourage collaborators to be proactive in contributing content and providing feedback, and we plan to continually improve our editorial process and overall capacity. As more collaborators join our collective, we will evolve with input from everyone. 

--- a/about.md
+++ b/about.md
@@ -23,7 +23,8 @@ We intend to run this project as a model of the organizing we believe in: grassr
 
 ### How we engage contributors and collaborators
 
-We welcome contributions for general themes (workplace surveillance and that eerie feeling of being watched), specific stories (a report of vacuum cleaning robots programmed to trip interns), or anything else that aligns with our vision and values.
+We welcome contributions for general themes (e.g., workplace surveillance),
+specific stories (e.g., organizing efforts at a particular workplace), or anything else that aligns with our vision and values.
 
 If you have suggestions, contributions, or proposals to collaborate, you can contact our collective by email: <twcnewsletter@protonmail.com>. You can also open a [GitHub issue](https://github.com/techworkersco/techworkersco.github.io/issues).
 

--- a/about.md
+++ b/about.md
@@ -9,9 +9,7 @@ This newsletter is a project within the [Tech Workers Coalition](https://www.tec
 
 The current editorial collective was formed in April 2020 by [Danny S](https://twitter.com/daspitzberg), [Wendy L](https://twitter.com/dellsystem), [Jesse S](https://twitter.com/jesse_squires), [Felipe V](https://twitter.com/fvntr) and [Ana U](https://anaulin.org/), all current or former tech workers based in the San Francisco Bay Area.
 
-We see ourselves as stewards, not owners, of this project, and hope for it to grow within the broader network. We do not (and can't possibly) speak for all of TWC.
-
-In 2018 and 2019, an early group of volunteers published a newsletter which is available on this website under [Volume 1](https://news.techworkerscoalition.org/archive/#volume-1). We’re grateful for their foundational work as we form a new group and restart the newsletter.
+We see ourselves as stewards, not owners, of this project, and hope for it to grow within the broader network. We do not (and can't possibly) speak for all of TWC. In 2018 and 2019, an early group of volunteers published a newsletter which is available on this website under [Volume 1](https://news.techworkerscoalition.org/archive/#volume-1). We’re grateful for their foundational work as we form a new group and restart the newsletter.
 
 ### Our vision and values
 


### PR DESCRIPTION
This PR adds a new "about" section to the header, and content explaining who we are and what is our intention for this newsletter.

@fvntr @dellsystem @jessesquires @stationaery please review

For reference, this is what it looks like within the site:
![Screen Shot 2020-04-30 at 8 43 41 PM](https://user-images.githubusercontent.com/6729309/80780359-8d5cb200-8b23-11ea-8e01-f1143d142eb7.png)
