### PR TITLE
Add base site URL to image include, so that full image URL for header images is available in the RSS feed

### DIFF
--- a/_includes/image.html
+++ b/_includes/image.html
@@ -1,5 +1,5 @@
 
-{% assign local_url = site.img_url | append: "/" | append: include.file %}
+{% assign local_url = site.url | append: site.img_url | append: "/" | append: include.file %}
 
 {% assign external_url = include.external_url %}
 


### PR DESCRIPTION
I believe this might help resolve https://github.com/techworkersco/techworkersco.github.io/issues/25

@jessesquires FYI (I'm going to merge as soon as build is green, so that I can test)