### PR TITLE
Update Image template and frontmatter to allow for an optional place to link the image to

### DIFF
--- a/_includes/image.html
+++ b/_includes/image.html
@@ -11,10 +11,15 @@
 
 {% assign half_width = include.half_width %}
 
+{% assign link_to = include.link_to %}
+
 <div class="row">
     <div class="col"></div>
     <div class="d-flex justify-content-center col-12 {% if half_width %} col-sm-8 col-md-6 {% endif %}">
         <figure>
+            {% if link_to %}
+              <a href="{{ link_to }}">
+            {% endif %}
             <img class="img-thumbnail img-fluid"
                  src="{{ external_url | default: local_url }}"
                  title="{{ alt }}"
@@ -36,6 +41,9 @@
                 {% endif %}
                 </div>
             </div>
+            {% if link_to %}
+              </a>
+            {% endif %}
         </figure>
     </div>
     <div class="col"></div>

--- a/_includes/post_image.html
+++ b/_includes/post_image.html
@@ -6,6 +6,7 @@
 {% assign img_caption = page.image.caption %}
 {% assign img_source = page.image.source_link %}
 {% assign img_width = page.image.half_width %}
+{% assign img_link_to = page.image.link_to %}
 
 {% include image.html
     file=img_file
@@ -13,6 +14,7 @@
     caption=img_caption
     source_link=img_source
     half_width=img_width
+    link_to=img_link_to
 %}
 
 {% endif %}

--- a/_posts/2020-05-01-issue-1.md
+++ b/_posts/2020-05-01-issue-1.md
@@ -6,6 +6,7 @@ image:
     file: vol-2-issue-1-header.png
     alt: Chris Smalls and essential workers talking the talk, walking the walk out.
     caption: Chris Smalls and essential workers talking the talk, walking the walk out.
+    link_to: https://twitter.com/Shut_downAmazon/status/1255681771292721158
     source_link: null
     half_width: false
 ---


### PR DESCRIPTION
This PR also adds a link to the Issue 1 (vol 2) header image. It doesn't change the formatting much, except that on hover it underlines the caption, and there is now a link that you are taken to, if you click.

