### PR TITLE
Tweak blockquote styles

### DIFF
--- a/_posts/2020-05-01-issue-1.md
+++ b/_posts/2020-05-01-issue-1.md
@@ -46,11 +46,11 @@ Solidarity with all gig workers gets complicated when customers enjoy the goods 
 Veena Dubal, Associate Professor of Law at U.C. Hastings, explains the [history of the gig economy](https://logicmag.io/security/a-brief-history-of-the-gig/) for the upcoming issue of _Logic Magazine_:
 
 > Samy, an Iranian refugee who emigrated to California in the 2000s, described the terrible conditions that he and many of these “independent contractors” face. Unable to afford the Bay Area, he lives a hundred miles away from San Francisco, and rather than commute to the city daily, he sleeps in his car between shifts, sometimes not returning home for several days in a row. “We have no freedom,” he told me. “I sleep in my car. I eat in my car. I work in my car. That is not freedom. That is not flexibility.”
-
+>
 > …
-
+>
 > While taxi companies had pioneered independent contracting in an earlier moment, technocapital’s flamboyant forms of neoliberal risk-shifting have catalyzed a powerful resistance to both the corporate practice of eschewing direct employment and worker reliance on state structures for security. The second neoliberal turn brought on by Uber and Lyft eradicated both municipal regulations and the limited sense of agency that workers had over their livelihoods. Ironically, this purge of state structures in the 2010s that drivers could leverage stirred new—but old—forms of collective activity. For the first time since the early 1980s, employment status—and more importantly, shared worker power built through the threat of employment status—has become a way for ride-hailing drivers to resist extreme economic insecurity and to collectively imagine better futures. 
-
+>
 > Workers are turning to one another to build power and effect change. Through protests, strikes, and other direct actions that have emerged through the fight for employment in California, drivers have found a much-needed source of friction that can stop, or at least slow, technocapital’s assault on their lives: solidarity.
 
 ## In Song

--- a/css/style.scss
+++ b/css/style.scss
@@ -4,7 +4,8 @@
 
 $color-brand: #e3252b;
 $color-brand-dark: #b01d21;
-$color-blockquote: #555;
+$color-blockquote: #555555;
+
 $margin-blockquote: 25px;
 
 a:link,
@@ -23,6 +24,9 @@ a:visited {
 blockquote {
   color: $color-blockquote;
   margin-left: $margin-blockquote;
+  margin-right: $margin-blockquote;
+  padding-left: 12px;
+  border-left: 2px solid $color-blockquote;
 }
 
 h2 {


### PR DESCRIPTION
Just a few minor style tweaks. I find this a bit more clear to read and understand that it's a quote, especially for longer text.

Thoughts?

Here's how it looks:

<img width="806" alt="Screen Shot 2020-05-02 at 8 52 25 PM" src="https://user-images.githubusercontent.com/2301114/80898343-1f48f400-8cb7-11ea-88e9-125d12cf9cf0.png">
