### PR TITLE
Add note on contacting us to site footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,18 +3,12 @@
 <hr width="50%">
 <p class="text-muted text-center">
     <small>
-        Want to contribute to this newsletter or share a story? We'd love to hear from you! Email
-        <a href="mailto:twcnewsletter@protonmail.com">twcnewsletter@protonmail.com</a>
-        or <a href="https://github.com/techworkersco/techworkersco.github.io/issues">open a new issue</a>.
-    </small>
-</p>
-
-<p class="text-center">
-    ✊🏼💛
-</p>
-
-<p class="text-muted text-center">
-    <small>
+        Want to contribute? <a href="mailto:twcnewsletter@protonmail.com">Email</a> us or
+        open a <a href="https://github.com/techworkersco/techworkersco.github.io/issues">GitHub
+        issue</a>.
+        <br/>
+        ✊🏼💛
+        <br/>
         A <a href="https://techworkerscoalition.org">Tech Workers Coalition</a> project.
         This site is <a href="{{ site.links.github }}">open source</a>.
     </small>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,8 +3,8 @@
 <hr width="50%">
 <p class="text-muted text-center">
     <small>
-        If you'd like to contribute to this newsletter, or have a story to share with us, we'd love
-        to hear from you. Write us at <a href="mailto:twcnewsletter@protonmail.com">twcnewsletter@protonmail.com</a>
+        Want to contribute to this newsletter or share a story? We'd love to hear from you! Email
+        <a href="mailto:twcnewsletter@protonmail.com">twcnewsletter@protonmail.com</a>
         or <a href="https://github.com/techworkersco/techworkersco.github.io/issues">open a new issue</a>.
     </small>
 </p>
@@ -15,8 +15,8 @@
 
 <p class="text-muted text-center">
     <small>
-        A <u><a href="https://techworkerscoalition.org">Tech Workers Coalition</a></u> project.
-        This site is <u><a href="{{ site.links.github }}">open source</a></u>.
+        A <a href="https://techworkerscoalition.org">Tech Workers Coalition</a> project.
+        This site is <a href="{{ site.links.github }}">open source</a>.
     </small>
 </p>
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,11 +3,11 @@
 <hr width="50%">
 <p class="text-muted text-center">
     <small>
-        Want to contribute? <a href="mailto:twcnewsletter@protonmail.com">Email</a> us or
+        Want to contribute? <a href="mailto:twcnewsletter@protonmail.com">Email us</a> or
         open a <a href="https://github.com/techworkersco/techworkersco.github.io/issues">GitHub
         issue</a>.
         <br/>
-        ✊🏼💛
+        ✊💛
         <br/>
         A <a href="https://techworkerscoalition.org">Tech Workers Coalition</a> project.
         This site is <a href="{{ site.links.github }}">open source</a>.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,6 +3,18 @@
 <hr width="50%">
 <p class="text-muted text-center">
     <small>
+        If you'd like to contribute to this newsletter, or have a story to share with us, we'd love
+        to hear from you. Write us at <a href="mailto:twcnewsletter@protonmail.com">twcnewsletter@protonmail.com</a>
+        or <a href="https://github.com/techworkersco/techworkersco.github.io/issues">open a new issue</a>.
+    </small>
+</p>
+
+<p class="text-center">
+    ✊🏼💛
+</p>
+
+<p class="text-muted text-center">
+    <small>
         A <u><a href="https://techworkerscoalition.org">Tech Workers Coalition</a></u> project.
         This site is <u><a href="{{ site.links.github }}">open source</a></u>.
     </small>


### PR DESCRIPTION
For https://github.com/techworkersco/techworkersco.github.io/issues/60.

This PR adds a note to the site footer to encourage readers to contact us with contributions or stories, with our email address and a link to GitHub issues. This will appear everywhere on the site, not just below newsletter issues. I also took the liberty of adding some emoji flair.

It looks like so:
<img width="858" alt="Screen Shot 2020-05-13 at 3 08 45 PM" src="https://user-images.githubusercontent.com/6729309/81870915-ad30a480-952b-11ea-8d10-9bca1e472beb.png">

Thoughts?