### PR TITLE
Style refinements

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -3,7 +3,7 @@
   <ul class="pagination justify-content-center">
     {% if page.previous.url %}
     <li class="page-item">
-      <a class="page-link" href="{{ page.previous.url }}" title="{{ page.previous.title }}" tabindex="-1">
+      <a class="page-link text-secondary" href="{{ page.previous.url }}" title="{{ page.previous.title }}">
       <i class="fa fa-chevron-left" aria-hidden="true"></i>
       Previous
       </a>
@@ -11,7 +11,7 @@
     {% endif %}
     {% if page.next.url %}
     <li class="page-item">
-      <a class="page-link" href="{{ page.next.url }}" title="{{ page.next.title }}">Next
+      <a class="page-link text-secondary" href="{{ page.next.url }}" title="{{ page.next.title }}">Next
       <i class="fa fa-chevron-right" aria-hidden="true"></i>
       </a>
     </li>

--- a/_includes/social_share.html
+++ b/_includes/social_share.html
@@ -1,10 +1,15 @@
+
 <nav aria-label="Share on social media">
     <ul class="pagination justify-content-center">
         <li class="page-item">
-            <a class="page-link" href="https://twitter.com/intent/tweet?text={{ page.title|url_encode }}%20via%20@twcnewsletter%20{{ page.url | absolute_url }}" title="Share on Twitter" target="_blank"><i class="fa fa-twitter"></i> Tweet</a>
+            <a class="page-link text-dark" href="https://twitter.com/intent/tweet?text={{ page.title|url_encode }}%20via%20@twcnewsletter%20{{ page.url | absolute_url }}" title="Share on Twitter" target="_blank">
+                <i class="fa fa-twitter"></i> Tweet
+            </a>
         </li>
         <li class="page-item">
-            <a class="page-link" href="https://www.facebook.com/sharer.php?u={{ page.url | absolute_url }}" title="Share on Facebook" target="_blank"><i class="fa fa-facebook"></i> Post</a>
+            <a class="page-link text-dark" href="https://www.facebook.com/sharer.php?u={{ page.url | absolute_url }}" title="Share on Facebook" target="_blank">
+                <i class="fa fa-facebook"></i> Post
+            </a>
         </li>
     </ul>
 </nav>

--- a/css/style.scss
+++ b/css/style.scss
@@ -18,7 +18,7 @@ a:hover {
 }
 
 a:visited {
-  color: $color-brand-dark;
+  color: $color-brand;
 }
 
 blockquote {


### PR DESCRIPTION
- Fix color + hover state of share + pagination

- Remove link visited color (this was mentioned in another PR. all links will now be the same color always.)

---

There were 2 issues:

1. I felt that the red links for prev/next and social sharing were competing a bit too much with the main content. Especially for the pagination at the top, next to the headline.

2. Because of bootstrap defaults, these buttons had a weird blue hover state.

### Before:

<img width="349" alt="Screen Shot 2020-05-14 at 11 11 53 AM" src="https://user-images.githubusercontent.com/2301114/81970213-fe946e80-95d3-11ea-80b3-102a006bffd1.png">

### After:

<img width="263" alt="Screen Shot 2020-05-14 at 11 09 47 AM" src="https://user-images.githubusercontent.com/2301114/81970224-048a4f80-95d4-11ea-992e-97cfa91cf686.png">

