### PR TITLE
Improve "latest" text on homepage

### DIFF
--- a/_includes/post_entry.html
+++ b/_includes/post_entry.html
@@ -1,6 +1,9 @@
 {% assign post_entry = include.post_entry %}
 
-<h2><a href="{{ post_entry.url }}">{{ post_entry.title }}</a></h2>
+<h2>
+    <a href="{{ post_entry.url }}">{{ post_entry.title }}</a>
+    {% if include.isLatest %}<small class="badge badge-dark">Latest</small>{% endif %}
+</h2>
 
 <h4 class="d-inline-block text-dark"><small>{{ post_entry.date | date_to_string }}</small></h4>
 

--- a/index.md
+++ b/index.md
@@ -2,12 +2,10 @@
 layout: default
 ---
 
-<h1 class="mb-2">Latest</h1>
-
 {% assign latest = site.posts.first %}
 
 <article>
-    {% include post_entry.html post_entry=latest display_excerpt=false %}
+    {% include post_entry.html post_entry=latest display_excerpt=false isLatest=true %}
     <div>
         {{ latest.content }}
     </div>


### PR DESCRIPTION
closes #24

i think this looks much better

### screenshot

<img width="1218" alt="Screen Shot 2020-05-23 at 1 06 23 PM" src="https://user-images.githubusercontent.com/2301114/82739674-5464c700-9cf6-11ea-9877-b6a7f434fa13.png">
