### PR TITLE
Update list of social media accounts for locals on Subscribe page

### DIFF
--- a/subscribe.md
+++ b/subscribe.md
@@ -15,20 +15,28 @@ title: Subscribe
 <h4 class="text-secondary">Twitter</h4>
 
 - [**@twcnewsletter**](https://twitter.com/twcnewsletter)
-- Austin: [@twcatx](https://twitter.com/twcatx)
-- Bangalore: [@twc_bangalore](https://twitter.com/twc_bangalore)
-- Bay Area: [@techworkersco](https://twitter.com/techworkersco)
-- Berlin: [@TechWorkersBER](https://twitter.com/TechWorkersBER)
-- Chicago: [@chicago_twc](https://twitter.com/chicago_twc)
-- DC: [@dctechworkers](https://twitter.com/dctechworkers)
-- Denver: [@twc_den](https://twitter.com/twc_den)
-- London: [@TechWorkersLDN](https://twitter.com/TechWorkersLDN)
-- NYC: [@techworkerscony](https://twitter.com/techworkerscony)
-- Portland: [@twc_pdx](https://twitter.com/twc_pdx)
-- San Diego: [@twcsandiego](https://twitter.com/twcsandiego)
+- International: [@techworkersco](https://twitter.com/techworkersco)
+- Asia
+  - Bangalore: [@twc_bangalore](https://twitter.com/twc_bangalore) and [@TechiesSpeakUp](https://twitter.com/TechiesSpeakUp)
+- Europe
+  - Berlin: [@TechWorkersBER](https://twitter.com/TechWorkersBER)
+  - Dublin (Tech Wont Build It): 	[@TWBIreland](https://twitter.com/TWBIIreland)
+  - London: [@TechWorkersLDN](https://twitter.com/TechWorkersLDN)
+- USA
+  - Austin:	[@twcatx](https://twitter.com/twcatx)
+  - Boston:	[@boston_twc](https://twitter.com/boston_twc)
+  - Chicago: [@chicago_twc](https://twitter.com/chicago_twc)
+  - Denver: [@twc_den](https://twitter.com/twc_den)
+  - Los Angeles: [@TWC_LosAngeles](https://twitter.com/TWC_LosAngeles)
+  - New York: [@techworkerscony](https://twitter.com/techworkerscony)
+  - San Diego: [@twcsandiego](https://twitter.com/twcsandiego)
+  - San Jose: [@twc_sanjose](https://twitter.com/twc_sanjose)
+  - Washington DC: [@dctechworkers](https://twitter.com/dctechworkers)
 
 <h4 class="text-secondary">Facebook</h4>
 
 - [**@TechWorkersCoalition**](https://www.facebook.com/TechWorkersCoalition)
+- Berlin: [@TechWorkersBER](https://www.facebook.com/TechWorkersBER)
 - London: [@TechWorkersLDN](https://www.facebook.com/TechWorkersLDN)
 - South Florida: [@southfltechworkers](https://www.facebook.com/southfltechworkers/)
+- Washington DC: [@DC-Tech-Workers-Coalition](https://www.facebook.com/pg/DC-Tech-Workers-Coalition-338770966854335)


### PR DESCRIPTION
This resolves https://github.com/techworkersco/techworkersco.github.io/issues/20.

Social media list updated with data from the spreadsheet linked to by @shushugah in the associated issue (although I note that we had at least one local Facebook page that is not in that spreadsheet).

The "Subscribe" page now will look like:
![Screen Shot 2020-06-17 at 3 32 17 PM](https://user-images.githubusercontent.com/6729309/84957316-ca6b0c80-b0af-11ea-8846-0bcf267107e3.png)
