### PR TITLE
Update 'latest' badge

### DIFF
--- a/_includes/post_entry.html
+++ b/_includes/post_entry.html
@@ -6,7 +6,11 @@
 
 <h4 class="d-inline-block text-dark">
     <small>{{ post_entry.date | date_to_string }}</small>
-    {% if include.isLatest %}<small class="badge badge-pill badge-dark"><i class="far fa-sm fa-star"></i> Latest</small>{% endif %}
+    {% if include.isLatest %}
+    <small class="badge badge-pill badge-dark font-weight-light">
+        <i class="far fa-sm fa-star"></i> Latest
+    </small>
+    {% endif %}
 </h4>
 
 {% if include.display_excerpt %}

--- a/_includes/post_entry.html
+++ b/_includes/post_entry.html
@@ -2,10 +2,12 @@
 
 <h2>
     <a href="{{ post_entry.url }}">{{ post_entry.title }}</a>
-    {% if include.isLatest %}<small class="badge badge-dark">Latest</small>{% endif %}
 </h2>
 
-<h4 class="d-inline-block text-dark"><small>{{ post_entry.date | date_to_string }}</small></h4>
+<h4 class="d-inline-block text-dark">
+    <small>{{ post_entry.date | date_to_string }}</small>
+    {% if include.isLatest %}<small class="badge badge-pill badge-dark"><i class="far fa-sm fa-star"></i> Latest</small>{% endif %}
+</h4>
 
 {% if include.display_excerpt %}
 <div>


### PR DESCRIPTION
Implements a new, less prominent design for the "Latest" badge on the main page. Per discussion in #79 

Bootstrap [has limited built-in colors](https://getbootstrap.com/docs/4.5/components/badge/) that we can use for this. I tried the gray ("secondary"), but I still think "dark" looks best with the rest of the content.

How it looks:

<img width="791" alt="Screen Shot 2020-06-26 at 9 58 22 AM" src="https://user-images.githubusercontent.com/2301114/85882172-ab493a80-b793-11ea-8a3a-3fe3192d5e45.png">
