### PR TITLE
Always display badge with latest post

### DIFF
--- a/_includes/post_entry.html
+++ b/_includes/post_entry.html
@@ -4,9 +4,16 @@
     <a href="{{ post_entry.url }}">{{ post_entry.title }}</a>
 </h2>
 
+{% assign latest_post = site.posts.first %}
+{% assign is_latest = false %}
+
+{% if latest_post.url == post_entry.url %}
+    {% assign is_latest = true %}
+{% endif %}
+
 <h4 class="d-inline-block text-dark">
     <small>{{ post_entry.date | date_to_string }}</small>
-    {% if include.isLatest %}
+    {% if is_latest %}
     <small class="badge badge-pill badge-dark font-weight-light">
         <i class="far fa-sm fa-star"></i> Latest
     </small>

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ layout: default
 {% assign latest = site.posts.first %}
 
 <article>
-    {% include post_entry.html post_entry=latest display_excerpt=false isLatest=true %}
+    {% include post_entry.html post_entry=latest display_excerpt=false %}
     <div>
         {{ latest.content }}
     </div>


### PR DESCRIPTION
It felt weird to me to see "Latest" on the home page, but nowhere else. (especially if you land on the main page, and click the issue title to go to the permalink.)

this makes it so the "latest" badge always displays on the most recent post.

<img width="1435" alt="Screen Shot 2020-07-10 at 9 25 24 AM" src="https://user-images.githubusercontent.com/2301114/87176852-8b377200-c28f-11ea-8e0e-26971ba00964.png">

<img width="1440" alt="Screen Shot 2020-07-10 at 9 25 36 AM" src="https://user-images.githubusercontent.com/2301114/87176873-912d5300-c28f-11ea-88cc-75cbfe064a0f.png">
