### PR TITLE
Improve display for post on home page

### DIFF
--- a/_includes/next.html
+++ b/_includes/next.html
@@ -1,0 +1,7 @@
+{% if include.url %}
+<li class="page-item">
+  <a class="page-link text-secondary" href="{{ include.url }}" title="{{ include.title }}">Next
+  <i class="fa fa-chevron-right" aria-hidden="true"></i>
+  </a>
+</li>
+{% endif %}

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -1,20 +1,7 @@
 
 <nav aria-label="Browse issues">
   <ul class="pagination justify-content-center">
-    {% if page.previous.url %}
-    <li class="page-item">
-      <a class="page-link text-secondary" href="{{ page.previous.url }}" title="{{ page.previous.title }}">
-      <i class="fa fa-chevron-left" aria-hidden="true"></i>
-      Previous
-      </a>
-    </li>
-    {% endif %}
-    {% if page.next.url %}
-    <li class="page-item">
-      <a class="page-link text-secondary" href="{{ page.next.url }}" title="{{ page.next.title }}">Next
-      <i class="fa fa-chevron-right" aria-hidden="true"></i>
-      </a>
-    </li>
-    {% endif %}
+    {% include previous.html url=page.previous.url title=page.previous.title %}
+    {% include next.html url=page.next.url title=page.next.title %}
   </ul>
 </nav>

--- a/_includes/post_entry.html
+++ b/_includes/post_entry.html
@@ -8,7 +8,9 @@
 {% assign is_latest = false %}
 
 {% if latest_post.url == post_entry.url %}
+    {% unless include.hide_latest_badge %}
     {% assign is_latest = true %}
+    {% endunless %}
 {% endif %}
 
 <h4 class="d-inline-block text-dark">

--- a/_includes/previous.html
+++ b/_includes/previous.html
@@ -1,0 +1,8 @@
+{% if include.url %}
+<li class="page-item">
+  <a class="page-link text-secondary" href="{{ include.url }}" title="{{ include.title }}">
+  <i class="fa fa-chevron-left" aria-hidden="true"></i>
+  Previous
+  </a>
+</li>
+{% endif %}

--- a/index.md
+++ b/index.md
@@ -3,30 +3,22 @@ layout: default
 ---
 
 {% assign latest = site.posts.first %}
-{% if site.posts.size > 1 %}
-{% assign previous = site.posts[1] %}
-{% endif %}
 
 <article>
-    {% if previous %}
-    <nav aria-label="See previous issue">
-        <ul class="pagination justify-content-center">
-        {% include previous.html url=previous.url title=previous.title %}
-        </ul>
-    </nav>
-    {% endif %}
-
     {% include post_entry.html post_entry=latest display_excerpt=false
     hide_latest_badge=true %}
     <div>
         {{ latest.content }}
     </div>
 
-    {% if previous %}
-    <nav aria-label="See previous issue">
+    <nav aria-label="Read more in the archives">
         <ul class="pagination justify-content-center">
-        {% include previous.html url=previous.url title=previous.title %}
+        <li class="page-item">
+            <a class="page-link text-secondary" href="/archive/" title="{{ include.title }}">
+                Read more in the archive
+                <i class="fa fa-chevron-right" aria-hidden="true"></i>
+            </a>
+            </li>
         </ul>
     </nav>
-    {% endif %}
 </article>

--- a/index.md
+++ b/index.md
@@ -3,10 +3,30 @@ layout: default
 ---
 
 {% assign latest = site.posts.first %}
+{% if site.posts.size > 1 %}
+{% assign previous = site.posts[1] %}
+{% endif %}
 
 <article>
-    {% include post_entry.html post_entry=latest display_excerpt=false %}
+    {% if previous %}
+    <nav aria-label="See previous issue">
+        <ul class="pagination justify-content-center">
+        {% include previous.html url=previous.url title=previous.title %}
+        </ul>
+    </nav>
+    {% endif %}
+
+    {% include post_entry.html post_entry=latest display_excerpt=false
+    hide_latest_badge=true %}
     <div>
         {{ latest.content }}
     </div>
+
+    {% if previous %}
+    <nav aria-label="See previous issue">
+        <ul class="pagination justify-content-center">
+        {% include previous.html url=previous.url title=previous.title %}
+        </ul>
+    </nav>
+    {% endif %}
 </article>


### PR DESCRIPTION
* The 'latest' badge is hidden from the home page
* The 'previous' button (from pagination.html) appears if needed, at the top and bottom of the page

Getting pagination to show up on the homepage was a bit of a pain, because Jekyll's built-in `previous` and `next` attributes are on the page variable, not post, and the homepage only has access to the latest post. Instead, we just use `site.posts[1]` (it's reverse chronological), which feels a little clunky but seems to work.

This PR would close #79.