### PR TITLE
Call for submissions page + editorial guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ For bug fixes or other enhancements for the site, feel free to [submit a pull re
 
 To fix a typo or otherwise correct the content in the newsletter, please [submit a pull request](https://github.com/techworkersco/techworkersco.github.io/compare) or [open an issue](https://github.com/techworkersco/techworkersco.github.io/issues/new) explaining what should be corrected.
 
-### Editorial
+## Editorial
 
 #### Content and format:
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,14 +6,40 @@
 
 Our [Code of Conduct](https://github.com/techworkersco/techworkersco.github.io/blob/master/.github/CODE_OF_CONDUCT.md) is in effect at all times.
 
+### Documentation
+
+Please read [our documentation here](https://github.com/techworkersco/techworkersco.github.io/blob/master/.github/DOCUMENTATION.md).
+
 ### Site Improvements
 
 For bug fixes or other enhancements for the site, feel free to [submit a pull request](https://github.com/techworkersco/techworkersco.github.io/compare) or [open an issue](https://github.com/techworkersco/techworkersco.github.io/issues/new). Please be clear and descriptive.
 
-### Content Corrections
+### Corrections
 
 To fix a typo or otherwise correct the content in the newsletter, please [submit a pull request](https://github.com/techworkersco/techworkersco.github.io/compare) or [open an issue](https://github.com/techworkersco/techworkersco.github.io/issues/new) explaining what should be corrected.
 
-### Documentation
+### Editorial
 
-Please read [our documentation here](https://github.com/techworkersco/techworkersco.github.io/blob/master/.github/DOCUMENTATION.md).
+#### Content and format:
+
+- Making sense of “what this moment means,” focusing on worker organizing to overcome challenges, the root causes of those challenges, or both.
+- Curated items we’re reading, highlighting contributions from around the world.
+- Historic perspective on past moments and trends in tech and labor organizing, especially those that are less known or missing in the Bay Area or US.
+- Song about labor or tech with a link and an excerpt from the lyrics.
+- Shareable: I hope we write articles that workers want to share with each other, and that this newsletter is another avenue of radicalization
+
+#### Qualities to strive for:
+
+- Interesting and enjoyable - our subscribers look forward to reading each issue.
+- Approachable - for tech workers who are unfamiliar with labor history or radical politics.
+- Timely and relevant - useful for making sense in the moment, and taking action.
+- Comprehensive - readers should feel that we’ve covered the important news.
+Succinct.
+
+#### Voice:
+
+- Committed and confident.
+- Friendly and optimistic where possible.
+- Not overly aggressive.
+- Thoughtful, well-reasoned, and persuasive, without guilting or brow-beating the reader.
+- The real deal: What workers say when the bosses aren’t listening

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-*Contributions are welcome and encouraged!*
+*Contributions are welcome, and encouraged!*
 
 ## Conduct
 
@@ -8,38 +8,12 @@ Our [Code of Conduct](https://github.com/techworkersco/techworkersco.github.io/b
 
 ## Documentation
 
-Please read [our documentation here](https://github.com/techworkersco/techworkersco.github.io/blob/master/.github/DOCUMENTATION.md).
+Please read [our technical documentation](https://github.com/techworkersco/techworkersco.github.io/blob/master/.github/DOCUMENTATION.md).
 
 ## Site Improvements
 
-For bug fixes or other enhancements for the site, feel free to [submit a pull request](https://github.com/techworkersco/techworkersco.github.io/compare) or [open an issue](https://github.com/techworkersco/techworkersco.github.io/issues/new). Please be clear and descriptive.
+For bug fixes or other enhancements for the site, feel free to [submit a pull request](https://github.com/techworkersco/techworkersco.github.io/compare) or [open an issue](https://github.com/techworkersco/techworkersco.github.io/issues/new). Please be clear and detailed!
 
 ## Corrections
 
 To fix a typo or otherwise correct the content in the newsletter, please [submit a pull request](https://github.com/techworkersco/techworkersco.github.io/compare) or [open an issue](https://github.com/techworkersco/techworkersco.github.io/issues/new) explaining what should be corrected.
-
-## Editorial
-
-### Content and format:
-
-- Making sense of “what this moment means,” focusing on worker organizing to overcome challenges, the root causes of those challenges, or both.
-- Curated items we’re reading, highlighting contributions from around the world.
-- Historic perspective on past moments and trends in tech and labor organizing, especially those that are less known or missing in the Bay Area or US.
-- Song about labor or tech with a link and an excerpt from the lyrics.
-- Shareable: I hope we write articles that workers want to share with each other, and that this newsletter is another avenue of radicalization
-
-### Qualities to strive for:
-
-- Interesting and enjoyable - our subscribers look forward to reading each issue.
-- Approachable - for tech workers who are unfamiliar with labor history or radical politics.
-- Timely and relevant - useful for making sense in the moment, and taking action.
-- Comprehensive - readers should feel that we’ve covered the important news.
-Succinct.
-
-### Voice:
-
-- Committed and confident.
-- Friendly and optimistic where possible.
-- Not overly aggressive.
-- Thoughtful, well-reasoned, and persuasive, without guilting or brow-beating the reader.
-- The real deal: What workers say when the bosses aren’t listening

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,6 +19,9 @@
                 <a class="nav-link {% if page.url == '/subscribe/' %}active{% endif %}" href="/subscribe/">subscribe</a>
             </li>
             <li class="nav-item mr-2">
+                <a class="nav-link {% if page.url == '/call-for-submissions/' %}active{% endif %}" href="/call-for-submissions/">contribute</a>
+            </li>
+            <li class="nav-item mr-2">
                 <a class="nav-link {% if page.url == '/search/' %}active{% endif %}" href="/search/"><i class="fas fa-search"></i></a>
             </li>
             <li class="nav-item mr-2">

--- a/call-for-submissions.md
+++ b/call-for-submissions.md
@@ -9,7 +9,7 @@ Are you a tech worker? Are you a content moderator, on-demand delivery driver, m
 </p>
 
 <p class="lead" markdown="1">
-This open call is for you!
+**This open call is for you!**
 </p>
 
 <p class="lead" markdown="1">

--- a/call-for-submissions.md
+++ b/call-for-submissions.md
@@ -21,9 +21,24 @@ Our editorial collective would love to hear your story and help you write. We’
 </p>
 </div>
 
+We’ll work closely with you to put your workers’ perspective in writing, 200-1,200 words. It's as much about the process and relationship as it is about the product we publish.
+
+<mark>We do this in service of our editorial vision:</mark>
+- Building critical consciousness of workers as a class with shared interests.
+- Sharing stories based on worker experience educating, organizing, and collective action in tech.
+- Challenging the industry’s dominant culture of individualism and its acceptance of gross inequality.
+- Situating ourselves in the history of labor organizing, both within the industry and beyond it.
+- Emphasizing the importance of solidarity with all workers.
+
 ### What we publish
 
-We’ll work with you to put your workers’ perspective in writing, 200-1200 words, based on your experience educating, organizing, and collective action in tech.
+<mark>Overall, we like to include a variety of content in the newsletter:</mark>
+- Original writing on topics we care about and can only address collectively.
+- News of tech worker organizing from around the globe, particularly efforts with grassroots leadership.
+- Perspectives from underrepresented tech workers about their experiences in the industry and what they see as its failures.
+- Analysis of what could be achieved through building collective power, contextualized within the long legacy of labor organizing in similar fields.
+- Rebuttals to common anti-organizing sentiments, like the idea that "someone else will build it" (they might not!).
+- Accounts of solidarity between different types of tech workers.
 
 <mark><a href="/archive/">Previous issues</a> have included a range of perspectives from tech workers:</mark>
 - Agonizing about framing anti-oppression organizing as ‘diversity training’ in tech.
@@ -37,20 +52,6 @@ We’ll work with you to put your workers’ perspective in writing, 200-1200 wo
 - The rare tale of actually using ‘unlimited’ paid time off.
 - Some kind of checklist for making algorithms slightly less racist.
 - A data scraping tool and newsfeed of company involvement with the military that helps inform overeager recruiters who they really work for.
-
-<mark>To put it in general terms, here is our editorial vision:</mark>
-- Building critical consciousness of workers as a class with shared interests.
-- Challenging the industry’s dominant culture of individualism and its acceptance of inequality.
-- Connecting to the history of labor organizing, both within the industry and beyond it.
-- Emphasizing the importance of solidarity with all workers.
-
-<mark>Overall, we like to include a variety of content in the newsletter:</mark>
-- Original writing on topics we care about and can only address collectively.
-- News of tech worker organizing from around the globe, particularly efforts with grassroots leadership.
-- Perspectives from underrepresented tech workers about their experiences in the industry and what they see as its failures.
-- Analysis of what could be achieved through building collective power, contextualized within the long legacy of labor organizing in similar fields.
-- Rebuttals to common anti-organizing sentiments, like the idea that "someone else will build it" (they might not!).
-- Accounts of solidarity between different types of tech workers.
 
 ### What we don’t publish
 

--- a/call-for-submissions.md
+++ b/call-for-submissions.md
@@ -17,7 +17,7 @@ Our editorial collective would love to hear your story and help you write. We’
 </p>
 
 <p class="lead" markdown="1">
-**Now, we're excited to share this open call for contributors and collaborators like you.**
+**We're excited to share this open call for contributors and collaborators.**
 </p>
 </div>
 
@@ -26,29 +26,25 @@ Our editorial collective would love to hear your story and help you write. We’
 We’ll work with you to put your workers’ perspective in writing, 200-1200 words, based on your experience educating, organizing, and collective action in tech.
 
 <mark><a href="/archive/">Previous issues</a> have included a range of perspectives from tech workers:</mark>
-
 - Agonizing about framing anti-oppression organizing as ‘diversity training’ in tech.
 - Weighing quitting a union job at a water treatment plant for a solar power co-op.
 - Running study groups with other temps, vendors, and contractors &mdash; and then organizing.
 - Conducting a six-month study on the ties between tech companies and the military, scraping data on 100,000+ contracts.
 
 <mark>In addition to your own work experience, we also welcome creative alternatives &mdash; for example:</mark>
-
 - A BuzzFeed quiz to see if you’re under surveillance.
 - A Yelp! review of tech union campaigns.
 - The rare tale of actually using ‘unlimited’ paid time off.
 - Some kind of checklist for making algorithms slightly less racist.
 - A data scraping tool and newsfeed of company involvement with the military that helps inform overeager recruiters who they really work for.
 
-<mark>Overall, to put it in general terms, here is our editorial vision:</mark>
-
+<mark>To put it in general terms, here is our editorial vision:</mark>
 - Building critical consciousness of workers as a class with shared interests.
 - Challenging the industry’s dominant culture of individualism and its acceptance of inequality.
 - Connecting to the history of labor organizing, both within the industry and beyond it.
 - Emphasizing the importance of solidarity with all workers.
 
 <mark>Overall, we like to include a variety of content in the newsletter:</mark>
-
 - Original writing on topics we care about and can only address collectively.
 - News of tech worker organizing from around the globe, particularly efforts with grassroots leadership.
 - Perspectives from underrepresented tech workers about their experiences in the industry and what they see as its failures.
@@ -56,16 +52,11 @@ We’ll work with you to put your workers’ perspective in writing, 200-1200 wo
 - Rebuttals to common anti-organizing sentiments, like the idea that "someone else will build it" (they might not!).
 - Accounts of solidarity between different types of tech workers.
 
-### Other ways to contribute
-
-<mark>In addition to workers’ perspective, we welcome collaborators who can help with news, history, and songs.</mark> We also could use more eyes on proofreading and more hands pushing publish each week, too! Engaging more collaborators is how we ensure the stewardship of this project for the long-term.
-
 ### What we don’t publish
 
 We prioritize the workers' perspective.
 
 <mark>Here are some examples of content we typically reject:</mark>
-
 - Critiques of tech imperialism, capitalism, injustice, etc. &mdash; or proposals for alternatives &mdash; that are not based on your lived experience.
 - Abstract or niche commentaries that lack a universal theme like work, working conditions, or solidarity beyond the workplace.
 - Narratives from corporate nonprofit staff or campaign consultants, not from workers.
@@ -77,10 +68,14 @@ We prioritize the workers' perspective.
 If you have an urge to talk about your experience, we’re here to help you figure out your best story and strategy.
 
 <mark>Here’s how to start the process:</mark>
-
 1. Email us your rough ideas or pitches to [twcnewsletter@protonmail.com](mailto:twcnewsletter@protonmail.com)!
 1. We’ll reach out to start a conversation.
 1. Then, we’ll help you get a first draft together
 1. We’ll also figure out anonymity and other security concerns with you.
 1. Depending on the story and strategy, we’ll move it fast or to give it more time.
 1. Finally, we publish!
+
+
+### Other ways to contribute
+
+<mark>In addition to workers’ perspective, we welcome collaborators who can help with news, history, and songs.</mark> We also could use more eyes on proofreading and more hands pushing publish each week, too! Engaging more collaborators is how we ensure the stewardship of this project for the long-term.

--- a/call-for-submissions.md
+++ b/call-for-submissions.md
@@ -1,6 +1,6 @@
 ---
 layout: standalone
-title: Call For Submissions
+title: Call for Submissions
 ---
 
 <div class="alert alert-secondary">
@@ -72,9 +72,9 @@ If you have an urge to talk about your experience, we’re here to help you figu
 1. Then, we’ll help you get a first draft together
 1. We’ll also figure out anonymity and other security concerns with you.
 1. Depending on the story and strategy, we’ll move it fast or to give it more time.
-1. Finally, we publish!
+1. Finally, we publish the piece!
 
 
 ### Other ways to contribute
 
-<mark>In addition to workers’ perspective, we welcome collaborators who can help with news, history, and songs.</mark> We also could use more eyes on proofreading and more hands pushing publish each week, too! Engaging more collaborators is how we ensure the stewardship of this project for the long-term.
+<mark>In addition to workers’ perspective, we welcome collaborators who can help with news, history, and songs.</mark> We also could use more eyes on proofreading and more hands pushing publish each week, too! Engaging more collaborators is how we ensure the stewardship of this project for the long-term. Sound interesting to you? Email is!

--- a/call-for-submissions.md
+++ b/call-for-submissions.md
@@ -3,3 +3,84 @@ layout: standalone
 title: Call For Submissions
 ---
 
+<div class="alert alert-dark">
+<p class="lead" markdown="1">
+Are you a tech worker? Are you a content moderator, on-demand delivery driver, machine learning engineer, or some other rank-and-file worker in the tech industry?
+</p>
+
+<p class="lead" markdown="1">
+**This open call is for you!**
+</p>
+
+<p class="lead" markdown="1">
+Our editorial collective would love to hear your story and help you write. We’ve been publishing a newsletter with workers’ perspectives since May 1, 2020, moving at the speed of trust and building reliable processes &mdash; you can read more in [our about page](/about/).
+</p>
+
+<p class="lead" markdown="1">
+**Now, we're excited to share this open call for contributors and collaborators like you.**
+</p>
+</div>
+
+### What we publish
+
+We’ll work with you to put your workers’ perspective in writing, 200-1200 words, based on your experience educating, organizing, and collective action in tech.
+
+<mark><a href="/archive/">Previous issues</a> have included a range of perspectives from tech workers:</mark>
+
+- Agonizing about framing anti-oppression organizing as ‘diversity training’ in tech.
+- Weighing quitting a union job at a water treatment plant for a solar power co-op.
+- Running study groups with other temps, vendors, and contractors &mdash; and then organizing.
+- Conducting a six-month study on the ties between tech companies and the military, scraping data on 100,000+ contracts.
+
+<mark>In addition to your own work experience, we also welcome creative alternatives &mdash; for example:</mark>
+
+- A BuzzFeed quiz to see if you’re under surveillance.
+- A Yelp! review of tech union campaigns.
+- The rare tale of actually using ‘unlimited’ paid time off.
+- Some kind of checklist for making algorithms slightly less racist.
+- A data scraping tool and newsfeed of company involvement with the military that helps inform overeager recruiters who they really work for.
+
+<mark>Overall, to put it in general terms, here is our editorial vision:</mark>
+
+- Building critical consciousness of workers as a class with shared interests.
+- Challenging the industry’s dominant culture of individualism and its acceptance of inequality.
+- Connecting to the history of labor organizing, both within the industry and beyond it.
+- Emphasizing the importance of solidarity with all workers.
+
+<mark>Overall, we like to include a variety of content in the newsletter:</mark>
+
+- Original writing on topics we care about and can only address collectively.
+- News of tech worker organizing from around the globe, particularly efforts with grassroots leadership.
+- Perspectives from underrepresented tech workers about their experiences in the industry and what they see as its failures.
+- Analysis of what could be achieved through building collective power, contextualized within the long legacy of labor organizing in similar fields.
+- Rebuttals to common anti-organizing sentiments, like the idea that "someone else will build it" (they might not!).
+- Accounts of solidarity between different types of tech workers.
+
+### Other ways to contribute
+
+<mark>In addition to workers’ perspective, we welcome collaborators who can help with news, history, and songs.</mark> We also could use more eyes on proofreading and more hands pushing publish each week, too! Engaging more collaborators is how we ensure the stewardship of this project for the long-term.
+
+### What we don’t publish
+
+We prioritize the workers' perspective.
+
+<mark>Here are some examples of content we typically reject:</mark>
+
+- Critiques of tech imperialism, capitalism, injustice, etc. &mdash; or proposals for alternatives &mdash; that are not based on your lived experience.
+- Abstract or niche commentaries that lack a universal theme like work, working conditions, or solidarity beyond the workplace.
+- Narratives from corporate nonprofit staff or campaign consultants, not from workers.
+- Anything that reads like a press release or impersonal op-ed.
+- General commentary on labor or the economy that doesn’t relate to the tech industry.
+
+### How to submit
+
+If you have an urge to talk about your experience, we’re here to help you figure out your best story and strategy.
+
+<mark>Here’s how to start the process:</mark>
+
+1. Email us your rough ideas or pitches to [twcnewsletter@protonmail.com](mailto:twcnewsletter@protonmail.com)!
+1. We’ll reach out to start a conversation.
+1. Then, we’ll help you get a first draft together
+1. We’ll also figure out anonymity and other security concerns with you.
+1. Depending on the story and strategy, we’ll move it fast or to give it more time.
+1. Finally, we publish!

--- a/call-for-submissions.md
+++ b/call-for-submissions.md
@@ -3,7 +3,7 @@ layout: standalone
 title: Call for Submissions
 ---
 
-<div class="alert alert-secondary">
+<div class="d-block bg-light pt-3 pl-3 pr-3 mt-4 mb-4 border rounded" markdown="1">
 <p class="lead" markdown="1">
 Are you a tech worker? Are you a content moderator, on-demand delivery driver, machine learning engineer, or some other rank-and-file worker in the tech industry?
 </p>

--- a/call-for-submissions.md
+++ b/call-for-submissions.md
@@ -21,7 +21,7 @@ We're excited to share this open call for contributors and collaborators.
 </p>
 </div>
 
-<mark>We’ll work closely with you to put your workers’ perspective in writing, 200 to 1,200 words. It's as much about the process and relationship as it is about the product we publish. We do this in service of our editorial vision:</mark>
+<mark>We work closely with you to put your workers’ perspective in writing, 200 to 1,200 words.</mark> It's as much about the process and relationship as it is about the product we publish. We do this in service of our editorial vision:
 
 - Building critical consciousness of workers as a class with shared interests.
 - Sharing stories based on worker experience educating, organizing, and collective action in tech.
@@ -31,23 +31,23 @@ We're excited to share this open call for contributors and collaborators.
 
 ### What we publish
 
-<mark>Overall, we like to include a variety of content in the newsletter:</mark>
+<mark>We welcome a variety of content from the workers' perspective:</mark>
 
 - Original writing on topics we care about and can only address collectively.
 - News of tech worker organizing from around the globe, particularly efforts with grassroots leadership.
 - Perspectives from underrepresented tech workers about their experiences in the industry and what they see as its failures.
-- Analysis of what could be achieved through building collective power, contextualized within the long legacy of labor organizing in similar fields.
+- Analysis of what can be achieved through building collective power, contextualized within the long legacy of labor organizing in similar fields.
 - Rebuttals to common anti-organizing sentiments, like the idea that "someone else will build it" (they might not!).
 - Accounts of solidarity between different types of tech workers.
 
-<mark><a href="/archive/">Previous issues</a> have included a range of perspectives from tech workers:</mark>
+<a href="/archive/">Previous issues</a> have included a range of perspectives from tech workers:
 
 - Agonizing about framing anti-oppression organizing as ‘diversity training’ in tech.
 - Weighing quitting a union job at a water treatment plant for a solar power co-op.
 - Running study groups with other temps, vendors, and contractors &mdash; and then organizing.
 - Conducting a six-month study on the ties between tech companies and the military, scraping data on 100,000+ contracts.
 
-<mark>In addition to your own work experience, we also welcome creative alternatives &mdash; for example:</mark>
+In addition to personal stories, we also welcome creative alternatives &mdash; for example:
 
 - A BuzzFeed quiz to see if you’re under surveillance.
 - A Yelp! review of tech union campaigns.
@@ -57,9 +57,9 @@ We're excited to share this open call for contributors and collaborators.
 
 ### What we don’t publish
 
-We prioritize the workers' perspective.
+We prioritize the workers' perspective and working people representing themselves.
 
-<mark>Here are some examples of content we typically reject:</mark>
+Here are some examples of content we typically reject:
 
 - Critiques of tech imperialism, capitalism, injustice, etc. &mdash; or proposals for alternatives &mdash; that are not based on your lived experience.
 - Abstract or niche commentaries that lack a universal theme like work, working conditions, or solidarity beyond the workplace.
@@ -69,18 +69,18 @@ We prioritize the workers' perspective.
 
 ### How to submit
 
-If you have an urge to talk about your experience, we’re here to help you figure out your best story and strategy.
+If you can share something with your fellow workers, we help you figure out a good story and strategy.
 
-<mark>Here’s how to start the process:</mark>
+Here’s how to start the process:
 
 1. Email us your rough ideas or pitches to [twcnewsletter@protonmail.com](mailto:twcnewsletter@protonmail.com)!
 1. We’ll reach out to start a conversation.
-1. Then, we’ll help you get a first draft together
-1. We’ll also figure out anonymity and other security concerns with you.
+1. Then, we’ll help you get a first draft together, usually in a phone call.
+1. We’ll also discuss and decide with you how to handle anonymity and other security considerations.
 1. Depending on the story and strategy, we’ll move it fast or to give it more time.
-1. Finally, we publish the piece!
+1. Finally, we publish the piece! Our newsletters currently comes out every other Friday.
 
 
 ### Other ways to contribute
 
-<mark>In addition to workers’ perspective, we welcome collaborators who can help with news, history, and songs.</mark> We also could use more eyes on proofreading and more hands pushing publish each week! Engaging more collaborators is how we ensure the stewardship of this project for the long-term. Sound interesting to you? [Email us](mailto:twcnewsletter@protonmail.com)!
+In addition to workers’ perspective, we welcome collaborators who can help with news, history, and songs. We also could use more eyes on proofreading and more hands pushing 'publish' each week! Engaging more collaborators is how we ensure the stewardship of this project for the long-term. Sound interesting to you? [Email us](mailto:twcnewsletter@protonmail.com)!

--- a/call-for-submissions.md
+++ b/call-for-submissions.md
@@ -1,0 +1,5 @@
+---
+layout: standalone
+title: Call For Submissions
+---
+

--- a/call-for-submissions.md
+++ b/call-for-submissions.md
@@ -21,7 +21,7 @@ We're excited to share this open call for contributors and collaborators.
 </p>
 </div>
 
-<mark>We’ll work closely with you to put your workers’ perspective in writing, 200-1,200 words. It's as much about the process and relationship as it is about the product we publish. We do this in service of our editorial vision:</mark>
+<mark>We’ll work closely with you to put your workers’ perspective in writing, 200 to 1,200 words. It's as much about the process and relationship as it is about the product we publish. We do this in service of our editorial vision:</mark>
 
 - Building critical consciousness of workers as a class with shared interests.
 - Sharing stories based on worker experience educating, organizing, and collective action in tech.
@@ -83,4 +83,4 @@ If you have an urge to talk about your experience, we’re here to help you figu
 
 ### Other ways to contribute
 
-<mark>In addition to workers’ perspective, we welcome collaborators who can help with news, history, and songs.</mark> We also could use more eyes on proofreading and more hands pushing publish each week, too! Engaging more collaborators is how we ensure the stewardship of this project for the long-term. Sound interesting to you? Email is!
+<mark>In addition to workers’ perspective, we welcome collaborators who can help with news, history, and songs.</mark> We also could use more eyes on proofreading and more hands pushing publish each week! Engaging more collaborators is how we ensure the stewardship of this project for the long-term. Sound interesting to you? Email us!

--- a/call-for-submissions.md
+++ b/call-for-submissions.md
@@ -9,7 +9,7 @@ Are you a tech worker? Are you a content moderator, on-demand delivery driver, m
 </p>
 
 <p class="lead" markdown="1">
-**This open call is for you!**
+This open call is for you!
 </p>
 
 <p class="lead" markdown="1">
@@ -17,13 +17,11 @@ Our editorial collective would love to hear your story and help you write. We’
 </p>
 
 <p class="lead" markdown="1">
-**We're excited to share this open call for contributors and collaborators.**
+We're excited to share this open call for contributors and collaborators.
 </p>
 </div>
 
-We’ll work closely with you to put your workers’ perspective in writing, 200-1,200 words. It's as much about the process and relationship as it is about the product we publish.
-
-<mark>We do this in service of our editorial vision:</mark>
+We’ll work closely with you to put your workers’ perspective in writing, 200-1,200 words. It's as much about the process and relationship as it is about the product we publish. We do this in service of our editorial vision:</mark>
 - Building critical consciousness of workers as a class with shared interests.
 - Sharing stories based on worker experience educating, organizing, and collective action in tech.
 - Challenging the industry’s dominant culture of individualism and its acceptance of gross inequality.

--- a/call-for-submissions.md
+++ b/call-for-submissions.md
@@ -5,7 +5,7 @@ title: Call for Submissions
 
 <div class="d-block bg-light pt-3 pl-3 pr-3 mt-4 mb-4 border rounded" markdown="1">
 <p class="lead" markdown="1">
-Are you a tech worker? Are you a content moderator, on-demand delivery driver, machine learning engineer, or some other rank-and-file worker in the tech industry?
+Are you a tech worker? Are you a content moderator, on-demand delivery driver, machine learning engineer, gig worker, security guard, or another rank-and-file worker in the tech industry?
 </p>
 
 <p class="lead" markdown="1">

--- a/call-for-submissions.md
+++ b/call-for-submissions.md
@@ -3,7 +3,7 @@ layout: standalone
 title: Call For Submissions
 ---
 
-<div class="alert alert-dark">
+<div class="alert alert-secondary">
 <p class="lead" markdown="1">
 Are you a tech worker? Are you a content moderator, on-demand delivery driver, machine learning engineer, or some other rank-and-file worker in the tech industry?
 </p>

--- a/call-for-submissions.md
+++ b/call-for-submissions.md
@@ -83,4 +83,4 @@ If you have an urge to talk about your experience, we’re here to help you figu
 
 ### Other ways to contribute
 
-<mark>In addition to workers’ perspective, we welcome collaborators who can help with news, history, and songs.</mark> We also could use more eyes on proofreading and more hands pushing publish each week! Engaging more collaborators is how we ensure the stewardship of this project for the long-term. Sound interesting to you? Email us!
+<mark>In addition to workers’ perspective, we welcome collaborators who can help with news, history, and songs.</mark> We also could use more eyes on proofreading and more hands pushing publish each week! Engaging more collaborators is how we ensure the stewardship of this project for the long-term. Sound interesting to you? [Email us](mailto:twcnewsletter@protonmail.com)!

--- a/call-for-submissions.md
+++ b/call-for-submissions.md
@@ -21,7 +21,8 @@ We're excited to share this open call for contributors and collaborators.
 </p>
 </div>
 
-We’ll work closely with you to put your workers’ perspective in writing, 200-1,200 words. It's as much about the process and relationship as it is about the product we publish. We do this in service of our editorial vision:</mark>
+<mark>We’ll work closely with you to put your workers’ perspective in writing, 200-1,200 words. It's as much about the process and relationship as it is about the product we publish. We do this in service of our editorial vision:</mark>
+
 - Building critical consciousness of workers as a class with shared interests.
 - Sharing stories based on worker experience educating, organizing, and collective action in tech.
 - Challenging the industry’s dominant culture of individualism and its acceptance of gross inequality.
@@ -31,6 +32,7 @@ We’ll work closely with you to put your workers’ perspective in writing, 200
 ### What we publish
 
 <mark>Overall, we like to include a variety of content in the newsletter:</mark>
+
 - Original writing on topics we care about and can only address collectively.
 - News of tech worker organizing from around the globe, particularly efforts with grassroots leadership.
 - Perspectives from underrepresented tech workers about their experiences in the industry and what they see as its failures.
@@ -39,12 +41,14 @@ We’ll work closely with you to put your workers’ perspective in writing, 200
 - Accounts of solidarity between different types of tech workers.
 
 <mark><a href="/archive/">Previous issues</a> have included a range of perspectives from tech workers:</mark>
+
 - Agonizing about framing anti-oppression organizing as ‘diversity training’ in tech.
 - Weighing quitting a union job at a water treatment plant for a solar power co-op.
 - Running study groups with other temps, vendors, and contractors &mdash; and then organizing.
 - Conducting a six-month study on the ties between tech companies and the military, scraping data on 100,000+ contracts.
 
 <mark>In addition to your own work experience, we also welcome creative alternatives &mdash; for example:</mark>
+
 - A BuzzFeed quiz to see if you’re under surveillance.
 - A Yelp! review of tech union campaigns.
 - The rare tale of actually using ‘unlimited’ paid time off.
@@ -56,6 +60,7 @@ We’ll work closely with you to put your workers’ perspective in writing, 200
 We prioritize the workers' perspective.
 
 <mark>Here are some examples of content we typically reject:</mark>
+
 - Critiques of tech imperialism, capitalism, injustice, etc. &mdash; or proposals for alternatives &mdash; that are not based on your lived experience.
 - Abstract or niche commentaries that lack a universal theme like work, working conditions, or solidarity beyond the workplace.
 - Narratives from corporate nonprofit staff or campaign consultants, not from workers.
@@ -67,6 +72,7 @@ We prioritize the workers' perspective.
 If you have an urge to talk about your experience, we’re here to help you figure out your best story and strategy.
 
 <mark>Here’s how to start the process:</mark>
+
 1. Email us your rough ideas or pitches to [twcnewsletter@protonmail.com](mailto:twcnewsletter@protonmail.com)!
 1. We’ll reach out to start a conversation.
 1. Then, we’ll help you get a first draft together


### PR DESCRIPTION
Ok folks, here we go.

###  "call for submissions"

 Submissions content was copied from the google doc and formatted. I made some _minor_ edits. 

I feel like this needed some styling/markup to breakup the content in a way that makes it more digestible. Totally open to ideas here.

### editorial guidelines

This is the bottom section from the google doc under *"The text below seems too much for including anywhere on the website"*

I think it made the most sense to add this to our existing `CONTRIBUTING.md` doc, which is also linked from the README in the repo. This is public, and thus easily sharable with contributors.

closes #55

Here's how it looks:

![Call For Submissions · TWC Newsletter](https://user-images.githubusercontent.com/2301114/91920939-2856cb80-ec7f-11ea-9667-96c05a9a3030.jpg)
