### PR TITLE
[CI] update danger workflow with fix

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           bundle config path vendor/bundle
           bundle install --without=documentation --jobs 4 --retry 3
-          echo "::add-path::/Users/runner/Library/Python/2.7/bin"
+          echo "/Users/runner/Library/Python/2.7/bin" >> $GITHUB_PATH
 
       - name: danger
         env:


### PR DESCRIPTION
webshits broke. 

webshits make fix.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/