### PR TITLE
Increase top/bottom margin around post content

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
 
 <article>
     {% include post_entry.html post_entry=page display_excerpt=false %}
-    <div>
+    <div class="mt-4 mb-4">
         {{ content }}
     </div>
 </article>


### PR DESCRIPTION
adds a bit more space below the post date and above the "tweet/post" buttons.