### PR TITLE
Improve link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -16,3 +16,4 @@ jobs:
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           check-modified-files-only: 'yes'
+          config-file: '.github/workflows/link_check_config.json'

--- a/.github/workflows/link_check_config.json
+++ b/.github/workflows/link_check_config.json
@@ -1,0 +1,7 @@
+{
+    "timeout": "20s",
+    "retryOn429": true,
+    "retryCount": 5,
+    "fallbackRetryDelay": "20s",
+    "aliveStatusCodes": [0, 200, 206]
+}

--- a/_posts/2021-02-05-issue-4.md
+++ b/_posts/2021-02-05-issue-4.md
@@ -109,3 +109,4 @@ What role can Asian people play in racial justice? We see a future following Jag
 > Wir sind die Roboter (We are the robots) <br>
 > Wir funktionieren automatik (We work automatically) <br>
 > Jetzt wollen wir tanzen mechanik (Now let's dance mechanically) <br>
+


### PR DESCRIPTION
There were issues at #184 with link checking.

Twitter links failed with status `0`: https://github.com/techworkersco/techworkersco.github.io/runs/1840130753

This just marks `0` as a success.