### PR TITLE
Use `jekyll.environment` for relative image URLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,6 @@ jobs:
           bundler-cache: true
 
       - name: jekyll build
-        run: bundle exec jekyll build --verbose --trace
+        run: |
+          echo "$JEKYLL_ENV"
+          bundle exec jekyll build --verbose --trace

--- a/_includes/image.html
+++ b/_includes/image.html
@@ -1,5 +1,17 @@
 
-{% assign local_url = site.url | append: site.img_url | append: "/" | append: include.file %}
+<!--
+For development and Netlify previews on PRs, use relative URLs.
+Otherwise, use absolute URLs so that images display in Mailchimp emails.
+
+See:
+  - https://jekyllrb.com/docs/configuration/environments/
+  - https://stackoverflow.com/questions/31274563/is-there-a-way-to-check-whether-a-jekyll-site-is-being-served-locally#31280149
+-->
+{% if jekyll.environment == "development" %}
+    {% assign local_url = site.img_url | append: "/" | append: include.file %}
+{% else %}
+    {% assign local_url = site.url | append: site.img_url | append: "/" | append: include.file %}
+{% endif %}
 
 {% assign external_url = include.external_url %}
 


### PR DESCRIPTION
For development and Netlify previews on PRs, use relative URLs.

Otherwise, use absolute URLs so that images display in Mailchimp emails.

See:
  - https://jekyllrb.com/docs/configuration/environments/
  - https://stackoverflow.com/questions/31274563/is-there-a-way-to-check-whether-a-jekyll-site-is-being-served-locally#31280149